### PR TITLE
ci: add seq logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,24 @@ on:
   push:
     branches:
       - master  # Change to your default branch if different
-
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'prod'
+        type: choice
+        options:
+        - prod
+      restart_iis:
+        description: 'Restart IIS after deployment'
+        required: true
+        default: true
+        type: boolean
+      create_release:
+        description: 'Create release'
+        required: true
+        default: true
 jobs:
   build:
     runs-on: self-hosted  # Ensure your self-hosted runner is configured
@@ -30,6 +47,39 @@ jobs:
 
     - name: Publish .NET Project
       run: dotnet publish ./services/bytefy.image/bytefy.image/bytefy.image.csproj --configuration Release --output ./output/dotnet
+
+
+    - name: Create placeholder appsettings for release
+      if: ${{ github.event.inputs.create_release != 'false' }}
+      run: |
+          $appSettings = @{
+              Logging = @{
+              LogLevel = @{
+                  Default = "Information"
+                  "Microsoft.AspNetCore" = "Warning"
+              }
+              }
+              AllowedHosts = "*"
+              Cors = @{
+              AllowedOrigins = @(
+                  "http://localhost:4200"
+                  "https://localhost:4200"
+              )
+              }
+              Seq = @{
+              ServerUrl = ${{ vars.SEQ_URL }}
+              ApiKey = ${{ secrets.seq_api_key }}
+              MinimumLevel = "Trace"
+                LevelOverride = @{
+                    Microsoft = "Warning"
+                }
+              }
+          }
+
+          $appSettings | ConvertTo-Json -Depth 10 | Set-Content -Path "./output/dotnet/appsettings.json"
+          Write-Host "Created placeholder appsettings.json successfully"
+
+
 
     - name: Install Node.js
       uses: actions/setup-node@v3
@@ -63,6 +113,7 @@ jobs:
 
   deploy:
     runs-on: self-hosted  # Ensure your self-hosted runner is configured
+    if: ${{ github.event.inputs.create_release != 'false' }}
     needs: build
 
     steps:
@@ -87,4 +138,26 @@ jobs:
       run: |
         xcopy ".\output\dotnet\*" "C:\inetpub\applications\bytefy.image" /s /i /y
         xcopy ".\bytefy.webapp\dist\browser\*" "C:\inetpub\wwwroot\bytefy" /s /i /y
+
+    - name: Restart IIS Application Pool
+      if: ${{ github.event.inputs.restart_iis != 'false' }}
+      run: |
+        Import-Module WebAdministration
+        $appPoolName = "${{ vars.IIS_APP_POOL_NAME }}"
+        if ([string]::IsNullOrEmpty($appPoolName)) {
+            $appPoolName = "HomeApi"
+        }
+
+        Write-Host "Starting application pool: $appPoolName"
+
+        # Check if app pool exists
+        if (Test-Path "IIS:\AppPools\$appPoolName") {
+          # Start app pool
+          Start-WebAppPool -Name $appPoolName
+          Write-Host "Application pool started successfully"
+        } else {
+          Write-Host "Warning: Application pool '$appPoolName' not found. Using IISReset instead."
+          iisreset /restart
+          Write-Host "IIS restarted successfully"
+        }
 

--- a/services/bytefy.image/bytefy.image/Program.cs
+++ b/services/bytefy.image/bytefy.image/Program.cs
@@ -7,6 +7,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAntiforgery(options => options.HeaderName = "2311d8d8-607d-4747-8939-1bde65643254");
 builder.Services.AddSingleton<ConversionQueueService>();
 builder.Services.AddHostedService(provider => provider.GetRequiredService<ConversionQueueService>());
+builder.Services.AddLogging(loggingBuilder =>
+{
+    loggingBuilder.AddSeq(builder.Configuration.GetSection("Seq"));
+});
 
 var corsSettings = builder.Configuration.GetSection("Cors").Get<CorsSettings>();
 

--- a/services/bytefy.image/bytefy.image/appsettings.Development.json
+++ b/services/bytefy.image/bytefy.image/appsettings.Development.json
@@ -11,5 +11,13 @@
       "http://localhost:4200",
       "https://localhost:4200"
     ]
+  },
+  "Seq": {
+    "ServerUrl": "https://log.azaaxin.com",
+    "ApiKey": "KEY",
+    "MinimumLevel": "Trace",
+    "LevelOverride": {
+      "Microsoft": "Warning"
+    }
   }
 }

--- a/services/bytefy.image/bytefy.image/appsettings.json
+++ b/services/bytefy.image/bytefy.image/appsettings.json
@@ -10,5 +10,13 @@
       "http://bytefy.net",
       "https://bytefy.net"
     ]
+  },
+  "Seq": {
+    "ServerUrl": "https://log.azaaxin.com",
+    "ApiKey": "KEY",
+    "MinimumLevel": "Trace",
+    "LevelOverride": {
+      "Microsoft": "Warning"
+    }
   }
 }

--- a/services/bytefy.image/bytefy.image/bytefy.image.csproj
+++ b/services/bytefy.image/bytefy.image/bytefy.image.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
       <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.0.0" />
       <PackageReference Include="Magick.NET.Core" Version="14.0.0" />
+      <PackageReference Include="Seq.Extensions.Logging" Version="8.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request introduces improvements to the deployment workflow and adds structured logging support to the backend service. The workflow now allows manual deployments with configurable options, generates a placeholder `appsettings.json` for releases, and can restart IIS as needed. Additionally, the backend service is updated to support Seq logging, with relevant configuration and dependencies added.

**Workflow enhancements:**

* Added `workflow_dispatch` to `.github/workflows/build.yml`, enabling manual deployments with configurable inputs for environment, IIS restart, and release creation.
* The build job now conditionally creates a placeholder `appsettings.json` with logging and CORS settings for releases.
* The deploy job is now conditional on the `create_release` input, allowing more flexible deployment control.
* Added a step to restart the IIS application pool after deployment, controlled by the `restart_iis` input.

**Backend logging improvements:**

* Integrated Seq structured logging by adding the `Seq.Extensions.Logging` NuGet package, updating `Program.cs` to configure Seq logging from the configuration, and adding `Seq` sections to both `appsettings.json` and `appsettings.Development.json`. [[1]](diffhunk://#diff-c18476eed6db41919ba9e4fe5e0966c0e7dd437ed0250a39fc12a84260c78581R21) [[2]](diffhunk://#diff-b2f846d7f019556efb1d86596d9c447f095176e85e0a5a4168f0e9abd44e093cR10-R13) [[3]](diffhunk://#diff-21764588b415a4fe7f315233b69ccaed510a61823cf36e80d5714c02a6fcc5b3R13-R20) [[4]](diffhunk://#diff-999ed73c1414778f987d8e09368fa998a4c42c1328a4eee5d1bd6fc4751e1293R14-R21)